### PR TITLE
Fix: Remove width assignment from sections

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -38,7 +38,6 @@ body {
 section {
   padding: var(--spacing-xlarge);
   flex: 1;
-  width: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
# Changes
- Removed `width: 100%` assignment from section elements, allowing for proper responsive styling (fixes horizontal scrollbar)