### PR TITLE
Implement password recovery flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,8 @@ test
 *.njsproj
 *.sln
 *.sw?
+
+# Supabase
+supabase/.temp/
+supabase/.branches/
+supabase/seed.sql

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -5,6 +5,7 @@ import { Result, err, ok } from '../utils/results';
 
 type AuthContextType = {
   session: Session | null;
+  isAuthLoading: boolean;
   signUp: (email: string, password: string) => Promise<Result<Session, Error>>;
   signIn: (email: string, password: string) => Promise<Result<Session, Error>>;
   signOut: () => Promise<Result<void, Error>>;
@@ -18,11 +19,15 @@ export const UserAuth = () => {
 
 export const AuthContextProvider = ({ children }: { children: React.ReactNode }) => {
   const [session, setSession] = useState<Session | null>(null);
+  const [isAuthLoading, setIsAuthLoading] = useState(true);
 
   const signUp = async (email: string, password: string) => {
     const { data, error } = await supabase.auth.signUp({
       email,
       password,
+      options: {
+        emailRedirectTo: `${window.location.origin}/signin`,
+      }
     })
 
     if (error) {
@@ -64,10 +69,13 @@ export const AuthContextProvider = ({ children }: { children: React.ReactNode })
   useEffect(() => {
     supabase.auth.getSession().then(({ data: { session } }) => {
       setSession(session);
+    }).finally(() => {
+      setIsAuthLoading(false);
     })
 
     const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
       setSession(session);
+      setIsAuthLoading(false);
     })
 
     return () => {
@@ -85,7 +93,7 @@ export const AuthContextProvider = ({ children }: { children: React.ReactNode })
   }
 
   return (
-    <AuthContext.Provider value={{ session, signUp, signIn, signOut }}>
+    <AuthContext.Provider value={{ session, isAuthLoading, signUp, signIn, signOut }}>
       {children}
     </AuthContext.Provider>
   )

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,25 +1,30 @@
+import type { AuthChangeEvent, Session } from '@supabase/supabase-js'
 import { createContext, useContext, useEffect, useState } from 'react'
+
 import supabase from '../data/supabaseClient'
-import { Session } from '@supabase/supabase-js';
-import { Result, err, ok } from '../utils/results';
+import { Result, err, ok } from '../utils/results'
 
 type AuthContextType = {
-  session: Session | null;
-  isAuthLoading: boolean;
-  signUp: (email: string, password: string) => Promise<Result<Session, Error>>;
-  signIn: (email: string, password: string) => Promise<Result<Session, Error>>;
-  signOut: () => Promise<Result<void, Error>>;
+  session: Session | null
+  isAuthLoading: boolean
+  isPasswordRecovery: boolean
+  signUp: (email: string, password: string) => Promise<Result<Session, Error>>
+  signIn: (email: string, password: string) => Promise<Result<Session, Error>>
+  signOut: () => Promise<Result<void, Error>>
+  resetPasswordForEmail: (email: string) => Promise<Result<void, Error>>
+  updatePassword: (password: string) => Promise<Result<void, Error>>
 }
 
-const AuthContext = createContext<AuthContextType | null>(null);
+const AuthContext = createContext<AuthContextType | null>(null)
 
 export const UserAuth = () => {
-  return useContext(AuthContext);
+  return useContext(AuthContext)
 }
 
 export const AuthContextProvider = ({ children }: { children: React.ReactNode }) => {
-  const [session, setSession] = useState<Session | null>(null);
-  const [isAuthLoading, setIsAuthLoading] = useState(true);
+  const [session, setSession] = useState<Session | null>(null)
+  const [isAuthLoading, setIsAuthLoading] = useState(true)
+  const [isPasswordRecovery, setIsPasswordRecovery] = useState(false)
 
   const signUp = async (email: string, password: string) => {
     const { data, error } = await supabase.auth.signUp({
@@ -27,22 +32,22 @@ export const AuthContextProvider = ({ children }: { children: React.ReactNode })
       password,
       options: {
         emailRedirectTo: `${window.location.origin}/signin`,
-      }
+      },
     })
 
     if (error) {
-      return err<Session>(error);
+      return err<Session>(error)
     }
 
     if (data?.session) {
-      setSession(data.session);
-      return ok<Session>(data.session);
+      setSession(data.session)
+      return ok<Session>(data.session)
     }
-    
+
     if (data?.user && !data?.session) {
-      return err<Session>(new Error('EMAIL_VERIFICATION_REQUIRED'));
+      return err<Session>(new Error('EMAIL_VERIFICATION_REQUIRED'))
     }
-    return err<Session>(new Error('Sign up successful but no session was created. Please try signing in.'));
+    return err<Session>(new Error('Sign up successful but no session was created. Please try signing in.'))
   }
 
   const signIn = async (email: string, password: string) => {
@@ -53,47 +58,108 @@ export const AuthContextProvider = ({ children }: { children: React.ReactNode })
       })
 
       if (error) {
-        return err<Session>(error);
+        return err<Session>(error)
       }
 
       if (data?.session) {
-        setSession(data.session);
-        return ok<Session>(data.session);
+        setSession(data.session)
+        setIsPasswordRecovery(false)
+        return ok<Session>(data.session)
       }
-      return err<Session>(new Error('Sign in successful but no session was created. Please try again.'));
+      return err<Session>(new Error('Sign in successful but no session was created. Please try again.'))
     } catch (error) {
-      return err<Session>(error as Error);
+      return err<Session>(error as Error)
     }
   }
 
-  useEffect(() => {
-    supabase.auth.getSession().then(({ data: { session } }) => {
-      setSession(session);
-    }).finally(() => {
-      setIsAuthLoading(false);
+  const resetPasswordForEmail = async (email: string) => {
+    const { error } = await supabase.auth.resetPasswordForEmail(email, {
+      redirectTo: `${window.location.origin}/update-password`,
     })
+    if (error) {
+      return err<void>(error)
+    }
+    return ok<void>(undefined)
+  }
 
-    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
-      setSession(session);
-      setIsAuthLoading(false);
+  const updatePassword = async (password: string) => {
+    const { error } = await supabase.auth.updateUser({ password })
+    if (error) {
+      return err<void>(error)
+    }
+    setIsPasswordRecovery(false)
+    return ok<void>(undefined)
+  }
+
+  useEffect(() => {
+    supabase.auth
+      .getSession()
+      .then(({ data: { session: initialSession } }) => {
+        setSession(initialSession)
+      })
+      .finally(() => {
+        setIsAuthLoading(false)
+      })
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((event: AuthChangeEvent, nextSession) => {
+      setSession(nextSession)
+      setIsAuthLoading(false)
+
+      switch (event) {
+        case 'INITIAL_SESSION':
+          break
+        case 'PASSWORD_RECOVERY':
+          setIsPasswordRecovery(true)
+          break
+        case 'SIGNED_IN':
+          setIsPasswordRecovery(false)
+          break
+        case 'SIGNED_OUT':
+          setIsPasswordRecovery(false)
+          break
+        case 'TOKEN_REFRESHED':
+          break
+        case 'USER_UPDATED':
+          break
+        case 'MFA_CHALLENGE_VERIFIED':
+          break
+        default: {
+          const _exhaustive: never = event
+          void _exhaustive
+        }
+      }
     })
 
     return () => {
-      subscription.unsubscribe();
+      subscription.unsubscribe()
     }
   }, [])
 
   const signOut = async () => {
-    const { error } = await supabase.auth.signOut();
+    const { error } = await supabase.auth.signOut()
     if (error) {
-      return err<void>(error);
+      return err<void>(error)
     }
-    setSession(null);
-    return ok<void>(undefined);
+    setSession(null)
+    setIsPasswordRecovery(false)
+    return ok<void>(undefined)
   }
 
   return (
-    <AuthContext.Provider value={{ session, isAuthLoading, signUp, signIn, signOut }}>
+    <AuthContext.Provider
+      value={{
+        session,
+        isAuthLoading,
+        isPasswordRecovery,
+        signUp,
+        signIn,
+        signOut,
+        resetPasswordForEmail,
+        updatePassword,
+      }}
+    >
       {children}
     </AuthContext.Provider>
   )

--- a/src/pages/ForgotPassword/ForgotPassword.tsx
+++ b/src/pages/ForgotPassword/ForgotPassword.tsx
@@ -1,0 +1,127 @@
+import { useState } from 'react'
+import { Link, Navigate } from 'react-router-dom'
+
+import '../Signin/Signin.css'
+import BackgroundFog from '../../components/Backgrounds/BackgroundFog'
+import { UserAuth } from '../../context/AuthContext'
+
+const ForgotPassword = () => {
+  const auth = UserAuth()!
+  const { session, isAuthLoading, isPasswordRecovery, resetPasswordForEmail } = auth
+
+  const [email, setEmail] = useState('')
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [emailSent, setEmailSent] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError('')
+    setLoading(true)
+    try {
+      const result = await resetPasswordForEmail(email)
+      if (result.isErr()) {
+        setError(result.error.message)
+        return
+      }
+      setEmailSent(true)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (isAuthLoading) {
+    return (
+      <div className="loading-container">
+        <div className="loading-spinner"></div>
+        <div className="loading-text">Checking session...</div>
+      </div>
+    )
+  }
+
+  if (session && isPasswordRecovery) {
+    return <Navigate to="/update-password" replace />
+  }
+
+  if (session) {
+    return <Navigate to="/" replace />
+  }
+
+  if (loading) {
+    return (
+      <div className="loading-container">
+        <div className="loading-spinner"></div>
+        <div className="loading-text">Sending reset link...</div>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <BackgroundFog highlightColor="#ff00ff" midtoneColor="#00ffff" lowlightColor="#7fff00" baseColor="#000000" />
+      <div className="signin-container">
+        <Link to="/" className="title">
+          Gaussian Explorer
+        </Link>
+        <div className="content-section signin-form-container">
+          {emailSent ? (
+            <div className="signin-form">
+              <h2 className="signin-title">Check your email</h2>
+              <p className="signin-text" style={{ textAlign: 'center' }}>
+                If an account exists for <strong>{email}</strong>, we sent a link to reset your password.
+              </p>
+              <div className="signin-footer">
+                <Link to="/signin" className="signin-link">
+                  Back to sign in
+                </Link>
+              </div>
+            </div>
+          ) : (
+            <>
+              <form onSubmit={handleSubmit} className="signin-form">
+                <h2 className="signin-title">Reset your password</h2>
+                <p className="signin-text" style={{ textAlign: 'center', marginBottom: '0.5rem' }}>
+                  Enter your email and we&apos;ll send you a link to choose a new password.
+                </p>
+
+                <div className="signin-form-group">
+                  <label htmlFor="email" className="signin-form-label">
+                    Email
+                  </label>
+                  <input
+                    id="email"
+                    name="email"
+                    type="email"
+                    required
+                    autoComplete="email"
+                    className="signin-form-input"
+                    value={email}
+                    onChange={(e) => {
+                      setEmail(e.target.value)
+                      if (error) setError('')
+                    }}
+                  />
+                </div>
+
+                <button type="submit" className="signin-submit-button">
+                  Send reset link
+                </button>
+                {error && <span className="signin-error-message">{error}</span>}
+              </form>
+
+              <div className="signin-footer">
+                <p className="signin-text">
+                  <Link to="/signin" className="signin-link">
+                    Back to sign in
+                  </Link>
+                </p>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </>
+  )
+}
+
+export default ForgotPassword

--- a/src/pages/Layout.tsx
+++ b/src/pages/Layout.tsx
@@ -1,10 +1,11 @@
 import { Navigate, Outlet } from "react-router-dom";
-import { UserAuth } from "../context/AuthContext";
+
 import Navbar from "../components/Navbar/Navbar";
+import { UserAuth } from "../context/AuthContext";
 
 const Layout = () => {
   const auth = UserAuth()!;
-  const { session, isAuthLoading } = auth;
+  const { session, isAuthLoading, isPasswordRecovery } = auth;
 
   if (isAuthLoading) {
     return (
@@ -12,6 +13,10 @@ const Layout = () => {
         Checking authentication...
       </main>
     );
+  }
+
+  if (session && isPasswordRecovery) {
+    return <Navigate to="/update-password" replace />;
   }
 
   if (!session) {

--- a/src/pages/Layout.tsx
+++ b/src/pages/Layout.tsx
@@ -1,18 +1,22 @@
-import { useEffect } from "react";
-import { Outlet, useNavigate } from "react-router-dom";
+import { Navigate, Outlet } from "react-router-dom";
 import { UserAuth } from "../context/AuthContext";
 import Navbar from "../components/Navbar/Navbar";
 
 const Layout = () => {
   const auth = UserAuth()!;
-  const { session } = auth;
-  const navigate = useNavigate();
+  const { session, isAuthLoading } = auth;
 
-  useEffect(() => {
-    if (!session) {
-      navigate('/');
-    }
-  }, [session, navigate]);
+  if (isAuthLoading) {
+    return (
+      <main style={{ marginTop: '70px', padding: '1rem' }}>
+        Checking authentication...
+      </main>
+    );
+  }
+
+  if (!session) {
+    return <Navigate to="/signin" replace />;
+  }
 
   return (
     <>

--- a/src/pages/Signin/Signin.tsx
+++ b/src/pages/Signin/Signin.tsx
@@ -1,13 +1,13 @@
+import { useState } from 'react'
 import { Link, Navigate, useNavigate } from 'react-router-dom'
 
 import './Signin.css'
 import BackgroundFog from '../../components/Backgrounds/BackgroundFog'
-import { UserAuth } from '../../context/AuthContext';
-import { useState } from 'react';
+import { UserAuth } from '../../context/AuthContext'
 
 const Signin = () => {
   const auth = UserAuth()!;
-  const { session, isAuthLoading, signIn } = auth;
+  const { session, isAuthLoading, isPasswordRecovery, signIn } = auth;
   const navigate = useNavigate();
 
   const [formData, setFormData] = useState({
@@ -60,6 +60,10 @@ const Signin = () => {
     )
   }
 
+  if (session && isPasswordRecovery) {
+    return <Navigate to="/update-password" replace />
+  }
+
   if (session) {
     return <Navigate to="/" replace />
   }
@@ -110,6 +114,11 @@ const Signin = () => {
                 value={formData.password}
                 onChange={handleChange}
               />
+              <div style={{ textAlign: 'right', marginTop: '0.25rem' }}>
+                <Link to="/forgot-password" className="signin-link" style={{ fontSize: '0.8125rem' }}>
+                  Forgot password?
+                </Link>
+              </div>
             </div>
 
             <button

--- a/src/pages/Signin/Signin.tsx
+++ b/src/pages/Signin/Signin.tsx
@@ -1,4 +1,4 @@
-import { Link, useNavigate } from 'react-router-dom'
+import { Link, Navigate, useNavigate } from 'react-router-dom'
 
 import './Signin.css'
 import BackgroundFog from '../../components/Backgrounds/BackgroundFog'
@@ -7,7 +7,7 @@ import { useState } from 'react';
 
 const Signin = () => {
   const auth = UserAuth()!;
-  const { signIn } = auth;
+  const { session, isAuthLoading, signIn } = auth;
   const navigate = useNavigate();
 
   const [formData, setFormData] = useState({
@@ -15,23 +15,20 @@ const Signin = () => {
     password: ''
   });
   const [errors, setErrors] = useState({
-    password: '',
     signin: ''
   })
   const [loading, setLoading] = useState(false);
 
   const handleSignIn = async (e: React.FormEvent) => {
     e.preventDefault();
+    setErrors({ signin: '' });
     setLoading(true);
     const { email, password } = formData;
     try {
       const result = await signIn(email, password);
       if (result.isErr()) {
         console.error(result.error);
-        setErrors(prev => ({
-          ...prev,
-          password: result.error.message
-        }));
+        setErrors({ signin: result.error.message });
       }
       if (result.isOk()) {
         navigate('/');
@@ -49,6 +46,22 @@ const Signin = () => {
       ...prev,
       [name]: value
     }));
+    if (errors.signin) {
+      setErrors({ signin: '' });
+    }
+  }
+
+  if (isAuthLoading) {
+    return (
+      <div className="loading-container">
+        <div className="loading-spinner"></div>
+        <div className="loading-text">Checking session...</div>
+      </div>
+    )
+  }
+
+  if (session) {
+    return <Navigate to="/" replace />
   }
 
   if (loading) {

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -1,4 +1,4 @@
-import { Link, useNavigate } from 'react-router-dom'
+import { Link, Navigate, useNavigate } from 'react-router-dom'
 import { useState } from 'react'
 
 import './Signup.css'
@@ -21,10 +21,10 @@ const Signup = () => {
 
   const navigate = useNavigate();
   const auth = UserAuth()!;
-  const { signUp } = auth;
+  const { session, isAuthLoading, signUp } = auth;
 
   const validatePasswords = () => {
-    const newErrors = { ...errors }
+    const newErrors = { ...errors, password: '', confirmPassword: '' }
     let isValid = true
 
     if (formData.password.length < 8) {
@@ -42,12 +42,14 @@ const Signup = () => {
   }
 
   const handleSignUp = async (e: React.FormEvent) => {
+    e.preventDefault();
+
     if (!validatePasswords()) {
       console.log('Passwords do not match');
       return;
     }
 
-    e.preventDefault();
+    setErrors(prev => ({ ...prev, signup: '' }));
     setLoading(true);
     const { email, password } = formData;
     try {
@@ -87,6 +89,13 @@ const Signup = () => {
         [name]: ''
       }))
     }
+
+    if (errors.signup) {
+      setErrors(prev => ({
+        ...prev,
+        signup: ''
+      }));
+    }
   }
 
   const emailVerificationNotice = (email: string) => {
@@ -109,6 +118,19 @@ const Signup = () => {
         </div>
       </div>
     )
+  }
+
+  if (isAuthLoading) {
+    return (
+      <div className="loading-container">
+        <div className="loading-spinner"></div>
+        <div className="loading-text">Checking session...</div>
+      </div>
+    )
+  }
+
+  if (session) {
+    return <Navigate to="/" replace />
   }
 
   if (loading) {

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -1,5 +1,5 @@
-import { Link, Navigate, useNavigate } from 'react-router-dom'
 import { useState } from 'react'
+import { Link, Navigate, useNavigate } from 'react-router-dom'
 
 import './Signup.css'
 import BackgroundFog from '../components/Backgrounds/BackgroundFog'
@@ -21,7 +21,7 @@ const Signup = () => {
 
   const navigate = useNavigate();
   const auth = UserAuth()!;
-  const { session, isAuthLoading, signUp } = auth;
+  const { session, isAuthLoading, isPasswordRecovery, signUp } = auth;
 
   const validatePasswords = () => {
     const newErrors = { ...errors, password: '', confirmPassword: '' }
@@ -127,6 +127,10 @@ const Signup = () => {
         <div className="loading-text">Checking session...</div>
       </div>
     )
+  }
+
+  if (session && isPasswordRecovery) {
+    return <Navigate to="/update-password" replace />
   }
 
   if (session) {

--- a/src/pages/UpdatePassword/UpdatePassword.tsx
+++ b/src/pages/UpdatePassword/UpdatePassword.tsx
@@ -1,0 +1,188 @@
+import { useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+
+import '../Signin/Signin.css'
+import BackgroundFog from '../../components/Backgrounds/BackgroundFog'
+import { UserAuth } from '../../context/AuthContext'
+
+const UpdatePassword = () => {
+  const auth = UserAuth()!
+  const { session, isAuthLoading, isPasswordRecovery, updatePassword } = auth
+  const navigate = useNavigate()
+
+  const [formData, setFormData] = useState({
+    password: '',
+    confirmPassword: '',
+  })
+  const [errors, setErrors] = useState({
+    password: '',
+    confirmPassword: '',
+    update: '',
+  })
+  const [loading, setLoading] = useState(false)
+
+  const validatePasswords = () => {
+    const next = { ...errors, password: '', confirmPassword: '' }
+    let isValid = true
+
+    if (formData.password.length < 8) {
+      next.password = 'Password must be at least 8 characters long'
+      isValid = false
+    }
+
+    if (formData.password !== formData.confirmPassword) {
+      next.confirmPassword = 'Passwords do not match'
+      isValid = false
+    }
+
+    setErrors(next)
+    return isValid
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!validatePasswords()) return
+
+    setErrors((prev) => ({ ...prev, update: '' }))
+    setLoading(true)
+    try {
+      const result = await updatePassword(formData.password)
+      if (result.isErr()) {
+        setErrors((prev) => ({ ...prev, update: result.error.message }))
+        return
+      }
+      navigate('/signin', { replace: true })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target
+    setFormData((prev) => ({ ...prev, [name]: value }))
+    if (name === 'password' || name === 'confirmPassword') {
+      setErrors((prev) => ({ ...prev, [name]: '' }))
+    }
+    if (errors.update) {
+      setErrors((prev) => ({ ...prev, update: '' }))
+    }
+  }
+
+  if (isAuthLoading) {
+    return (
+      <div className="loading-container">
+        <div className="loading-spinner"></div>
+        <div className="loading-text">Checking session...</div>
+      </div>
+    )
+  }
+
+  if (!session) {
+    return (
+      <>
+        <BackgroundFog highlightColor="#ff00ff" midtoneColor="#00ffff" lowlightColor="#7fff00" baseColor="#000000" />
+        <div className="signin-container">
+          <Link to="/" className="title">
+            Gaussian Explorer
+          </Link>
+          <div className="content-section signin-form-container">
+            <div className="signin-form">
+              <h2 className="signin-title">Link invalid or expired</h2>
+              <p className="signin-text" style={{ textAlign: 'center' }}>
+                Open the reset link from your email, or request a new password reset.
+              </p>
+              <div className="signin-footer">
+                <Link to="/forgot-password" className="signin-link">
+                  Request a new link
+                </Link>
+                {' · '}
+                <Link to="/signin" className="signin-link">
+                  Sign in
+                </Link>
+              </div>
+            </div>
+          </div>
+        </div>
+      </>
+    )
+  }
+
+  if (loading) {
+    return (
+      <div className="loading-container">
+        <div className="loading-spinner"></div>
+        <div className="loading-text">Updating password...</div>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <BackgroundFog highlightColor="#ff00ff" midtoneColor="#00ffff" lowlightColor="#7fff00" baseColor="#000000" />
+      <div className="signin-container">
+        <Link to="/" className="title">
+          Gaussian Explorer
+        </Link>
+        <div className="content-section signin-form-container">
+          <form onSubmit={handleSubmit} className="signin-form">
+            <h2 className="signin-title">Choose a new password</h2>
+            {!isPasswordRecovery && (
+              <p className="signin-text" style={{ textAlign: 'center', fontSize: '0.9rem' }}>
+                You can update your password while signed in.
+              </p>
+            )}
+
+            <div className="signin-form-group">
+              <label htmlFor="password" className="signin-form-label">
+                New password
+              </label>
+              <input
+                id="password"
+                name="password"
+                type="password"
+                required
+                autoComplete="new-password"
+                className={`signin-form-input ${errors.password ? 'signin-form-input-error' : ''}`}
+                value={formData.password}
+                onChange={handleChange}
+              />
+              {errors.password && <span className="signin-error-message">{errors.password}</span>}
+            </div>
+
+            <div className="signin-form-group">
+              <label htmlFor="confirmPassword" className="signin-form-label">
+                Confirm new password
+              </label>
+              <input
+                id="confirmPassword"
+                name="confirmPassword"
+                type="password"
+                required
+                autoComplete="new-password"
+                className={`signin-form-input ${errors.confirmPassword ? 'signin-form-input-error' : ''}`}
+                value={formData.confirmPassword}
+                onChange={handleChange}
+              />
+              {errors.confirmPassword && <span className="signin-error-message">{errors.confirmPassword}</span>}
+            </div>
+
+            <button type="submit" className="signin-submit-button">
+              Update password
+            </button>
+            {errors.update && <span className="signin-error-message">{errors.update}</span>}
+          </form>
+
+          <div className="signin-footer">
+            <p className="signin-text">
+              <Link to="/signin" className="signin-link">
+                Back to sign in
+              </Link>
+            </p>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}
+
+export default UpdatePassword

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,9 +1,12 @@
 import { createBrowserRouter } from 'react-router-dom'
+
 import App from './App'
+import ForgotPassword from './pages/ForgotPassword/ForgotPassword'
+import Home from './pages/Home/Home'
+import Layout from './pages/Layout'
 import Signin from './pages/Signin/Signin'
 import Signup from './pages/Signup'
-import Layout from './pages/Layout'
-import Home from './pages/Home/Home'
+import UpdatePassword from './pages/UpdatePassword/UpdatePassword'
 
 export const router = createBrowserRouter([
   {
@@ -15,6 +18,8 @@ export const router = createBrowserRouter([
       },
       { path: 'signin', element: <Signin /> },
       { path: 'signup', element: <Signup /> },
+      { path: 'forgot-password', element: <ForgotPassword /> },
+      { path: 'update-password', element: <UpdatePassword /> },
     ]
   },
 ])

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -10,11 +10,11 @@ export const router = createBrowserRouter([
     path: '/', element: <App />, children: [
       {
         path: '/', element: <Layout />, children: [
-          { path: '/', element: <Home /> },
+          { index: true, element: <Home /> },
         ]
       },
-      { path: '/signin', element: <Signin /> },
-      { path: '/signup', element: <Signup /> },
+      { path: 'signin', element: <Signin /> },
+      { path: 'signup', element: <Signup /> },
     ]
   },
 ])

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -231,15 +231,19 @@ subject = "Confirm Your Signup"
 content_path = "./supabase/templates/confirmation.html"
 
 # Uncomment to customize email template
-# [auth.email.template.invite]
-# subject = "You have been invited"
-# content_path = "./supabase/templates/invite.html"
+[auth.email.template.invite]
+subject = "You have been invited"
+content_path = "./supabase/templates/invite.html"
 
 # Uncomment to customize notification email template
-# [auth.email.notification.password_changed]
-# enabled = true
-# subject = "Your password has been changed"
-# content_path = "./templates/password_changed_notification.html"
+[auth.email.notification.password_changed]
+enabled = true
+subject = "Your password has been changed"
+content_path = "./templates/password_changed_notification.html"
+
+[auth.email.template.recovery]
+subject = "Reset Your Password"
+content_path = "./supabase/templates/recovery.html"
 
 [auth.sms]
 # Allow/disallow new user signups via SMS to your project.

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -226,6 +226,10 @@ pass = ""
 admin_email = "admin@email.com"
 sender_name = "Admin"
 
+[auth.email.template.confirmation]
+subject = "Confirm Your Signup"
+content_path = "./supabase/templates/confirmation.html"
+
 # Uncomment to customize email template
 # [auth.email.template.invite]
 # subject = "You have been invited"

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,388 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "gaussian-explorer-supabase"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+# Paths to self-signed certificate pair.
+# cert_path = "../certs/my-cert.pem"
+# key_path = "../certs/my-key.pem"
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# Maximum amount of time to wait for health check when starting the local database.
+health_timeout = "2m"
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 17
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+# [db.vault]
+# secret_key = "env(SECRET_VALUE)"
+
+[db.migrations]
+# If disabled, migrations will be skipped during a db push or reset.
+enabled = true
+# Specifies an ordered list of schema files that describe your database.
+# Supports glob patterns relative to supabase directory: "./schemas/*.sql"
+schema_paths = []
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = ["./seed.sql"]
+
+[db.network_restrictions]
+# Enable management of network restrictions.
+enabled = false
+# List of IPv4 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv4 connections. Set empty array to block all IPs.
+allowed_cidrs = ["0.0.0.0/0"]
+# List of IPv6 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv6 connections. Set empty array to block all IPs.
+allowed_cidrs_v6 = ["::/0"]
+
+# Uncomment to reject non-secure connections to the database.
+# [db.ssl_enforcement]
+# enabled = true
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[inbucket]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+# Uncomment to configure local storage buckets
+# [storage.buckets.images]
+# public = false
+# file_size_limit = "50MiB"
+# allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
+
+# Allow connections via S3 compatible clients
+[storage.s3_protocol]
+enabled = true
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Store analytical data in S3 for running ETL jobs over Iceberg Catalog
+# This feature is only available on the hosted platform.
+[storage.analytics]
+enabled = false
+max_namespaces = 5
+max_tables = 10
+max_catalogs = 2
+
+# Analytics Buckets is available to Supabase Pro plan.
+# [storage.analytics.buckets.my-warehouse]
+
+# Store vector embeddings in S3 for large and durable datasets
+# This feature is only available on the hosted platform.
+[storage.vector]
+enabled = false
+max_buckets = 10
+max_indexes = 5
+
+# Vector Buckets is available to Supabase Pro plan.
+# [storage.vector.buckets.documents-openai]
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://localhost:5173"
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["http://localhost:5173", "http://localhost:5173/signin"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# JWT issuer URL. If not set, defaults to the local API URL (http://127.0.0.1:<port>/auth/v1).
+# jwt_issuer = ""
+# Path to JWT signing key. DO NOT commit your signing keys file to git.
+# signing_keys_path = "./signing_keys.json"
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = false
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+[auth.rate_limit]
+# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
+email_sent = 2
+# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+sms_sent = 30
+# Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
+anonymous_users = 30
+# Number of sessions that can be refreshed in a 5 minute interval per IP address.
+token_refresh = 150
+# Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
+sign_in_sign_ups = 30
+# Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
+token_verifications = 30
+# Number of Web3 logins that can be made in a 5 minute interval per IP address.
+web3 = 30
+
+# Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
+# [auth.captcha]
+# enabled = true
+# provider = "hcaptcha"
+# secret = ""
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = true
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+secure_password_change = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+[auth.email.smtp]
+enabled = false
+host = "127.0.0.1"
+port = 1025
+user = ""
+pass = ""
+admin_email = "admin@email.com"
+sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+# Uncomment to customize notification email template
+# [auth.email.notification.password_changed]
+# enabled = true
+# subject = "Your password has been changed"
+# content_path = "./templates/password_changed_notification.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ .Code }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a new user is created and allows developers to reject the request based on the incoming user object.
+# [auth.hook.before_user_created]
+# enabled = true
+# uri = "pg-functions://postgres/auth/before-user-created-hook"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ .Code }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `x`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth redirectUrl.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+# If enabled, it will allow the user to successfully authenticate when the provider does not return an email address.
+email_optional = false
+
+# Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
+# You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.
+[auth.web3.solana]
+enabled = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
+
+# OAuth server configuration
+[auth.oauth_server]
+# Enable OAuth server functionality
+enabled = false
+# Path for OAuth consent flow UI
+authorization_url_path = "/oauth/consent"
+# Allow dynamic client registration
+allow_dynamic_registration = false
+
+[edge_runtime]
+enabled = true
+# Supported request policies: `oneshot`, `per_worker`.
+# `per_worker` (default) — enables hot reload during local development.
+# `oneshot` — fallback mode if hot reload causes issues (e.g. in large repos or with symlinks).
+policy = "per_worker"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+# The Deno major version to use.
+deno_version = 2
+
+# [edge_runtime.secrets]
+# secret_key = "env(SECRET_VALUE)"
+
+[analytics]
+enabled = true
+port = 54327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -153,7 +153,12 @@ enabled = true
 # in emails.
 site_url = "http://localhost:5173"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["http://localhost:5173", "http://localhost:5173/signin"]
+additional_redirect_urls = [
+  "http://localhost:5173",
+  "http://localhost:5173/signin",
+  "http://localhost:5173/forgot-password",
+  "http://localhost:5173/update-password",
+]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
 # JWT issuer URL. If not set, defaults to the local API URL (http://127.0.0.1:<port>/auth/v1).

--- a/supabase/templates/confirmation.html
+++ b/supabase/templates/confirmation.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Confirm Your Signup</title>
+</head>
+
+<body
+  style="margin:0; padding:0; background-color:#f4f4f5; font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="padding:40px 20px;">
+    <tr>
+      <td align="center">
+        <table width="480" cellpadding="0" cellspacing="0" style="background:#ffffff; border-radius:8px; padding:40px;">
+          <tr>
+            <td>
+              <h1 style="margin:0 0 16px; font-size:24px; color:#18181b;">Confirm your email</h1>
+              <p style="margin:0 0 24px; font-size:15px; line-height:1.6; color:#52525b;">
+                Thanks for signing up! Please confirm your email address to get started.
+              </p>
+              <a href="{{ .ConfirmationURL }}"
+                style="display:inline-block; padding:12px 32px; background-color:#2563eb; color:#ffffff; text-decoration:none; border-radius:6px; font-size:15px; font-weight:600;">
+                Confirm Email
+              </a>
+              <p style="margin:32px 0 0; font-size:13px; color:#a1a1aa;">
+                If you didn't create an account, you can safely ignore this email.
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+
+</html>

--- a/supabase/templates/invite.html
+++ b/supabase/templates/invite.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>You have been invited</title>
+</head>
+
+<body
+  style="margin:0; padding:0; background-color:#f4f4f5; font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="padding:40px 20px;">
+    <tr>
+      <td align="center">
+        <table width="480" cellpadding="0" cellspacing="0" style="background:#ffffff; border-radius:8px; padding:40px;">
+          <tr>
+            <td>
+              <h1 style="margin:0 0 16px; font-size:24px; color:#18181b;">You're invited</h1>
+              <p style="margin:0 0 24px; font-size:15px; line-height:1.6; color:#52525b;">
+                You've been invited to join. Accept the invitation to create your account and get started.
+              </p>
+              <a href="{{ .ConfirmationURL }}"
+                style="display:inline-block; padding:12px 32px; background-color:#2563eb; color:#ffffff; text-decoration:none; border-radius:6px; font-size:15px; font-weight:600;">
+                Accept invitation
+              </a>
+              <p style="margin:32px 0 0; font-size:13px; color:#a1a1aa;">
+                If you weren't expecting this invitation, you can safely ignore this email.
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+
+</html>

--- a/supabase/templates/password_changed_notification.html
+++ b/supabase/templates/password_changed_notification.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Your password has been changed</title>
+</head>
+
+<body
+  style="margin:0; padding:0; background-color:#f4f4f5; font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="padding:40px 20px;">
+    <tr>
+      <td align="center">
+        <table width="480" cellpadding="0" cellspacing="0" style="background:#ffffff; border-radius:8px; padding:40px;">
+          <tr>
+            <td>
+              <h1 style="margin:0 0 16px; font-size:24px; color:#18181b;">Password changed</h1>
+              <p style="margin:0 0 24px; font-size:15px; line-height:1.6; color:#52525b;">
+                This is a confirmation that the password for your account <strong>{{ .Email }}</strong> has just been changed.
+              </p>
+              <p style="margin:0 0 24px; font-size:15px; line-height:1.6; color:#52525b;">
+                If you made this change, no further action is needed.
+              </p>
+              <p style="margin:0; font-size:13px; color:#a1a1aa;">
+                If you did not make this change, please reset your password and contact support.
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+
+</html>

--- a/supabase/templates/recovery.html
+++ b/supabase/templates/recovery.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Reset Your Password</title>
+</head>
+
+<body
+  style="margin:0; padding:0; background-color:#f4f4f5; font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="padding:40px 20px;">
+    <tr>
+      <td align="center">
+        <table width="480" cellpadding="0" cellspacing="0" style="background:#ffffff; border-radius:8px; padding:40px;">
+          <tr>
+            <td>
+              <h1 style="margin:0 0 16px; font-size:24px; color:#18181b;">Reset your password</h1>
+              <p style="margin:0 0 24px; font-size:15px; line-height:1.6; color:#52525b;">
+                We received a request to reset the password for <strong>{{ .Email }}</strong>. Click the button below to choose a new password.
+              </p>
+              <a href="{{ .ConfirmationURL }}"
+                style="display:inline-block; padding:12px 32px; background-color:#2563eb; color:#ffffff; text-decoration:none; border-radius:6px; font-size:15px; font-weight:600;">
+                Reset password
+              </a>
+              <p style="margin:32px 0 0; font-size:13px; color:#a1a1aa;">
+                If you didn't request a password reset, you can safely ignore this email.
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+
+</html>


### PR DESCRIPTION
## Summary
- add Supabase-style forgot-password and update-password routes for the email recovery flow
- handle PASSWORD_RECOVERY in the auth context so inbox redirects land on the password update screen instead of bouncing away
- include local Supabase auth redirect and email template updates needed for the recovery flow

## Test plan
- [x] Run 
pm run build
- [x] Run through the local password reset flow from the Supabase inbox and confirm the email link opens /update-password
- [x] Confirm submitting a new password succeeds and the user can sign in with the new password